### PR TITLE
refactor(adapters): session init and id tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,9 @@ console.log(rsaPublicSpki);
 
 ### Adapters
 
+> [!WARNING]
+> While these adapters try to be compatible with h3's `useSession` API, the key difference is that new sessions are not automatically created when calling `useJWESession` or `useJWSSession`, marking their `id` as `undefined` until you explicitly call `session.update()`. This is to comply with various specs that do integrate JWT one (such as OAuth) where sessions are only created upon valid operations (like user authorization).
+
 #### H3 v1 (Nuxt v4, Nitro v2)
 
 The `h3v1` adapter bundles session helpers that store data inside signed or encrypted JWTs.

--- a/src/adapters/h3v1/README.md
+++ b/src/adapters/h3v1/README.md
@@ -2,6 +2,9 @@
 
 The `h3` adapter bundles session helpers that store data inside signed or encrypted JWTs.
 
+> [!WARNING]
+> While these adapters try to be compatible with h3's `useSession` API, the key difference is that new sessions are not automatically created when calling `useJWESession` or `useJWSSession`, marking their `id` as `undefined` until you explicitly call `session.update()`. This is to comply with various specs that do integrate JWT one (such as OAuth) where sessions are only created upon valid operations (like user authorization).
+
 For an in-depth guide on using these adapters, please refer to the [H3 Session Adapters - Usage Guide](../../../docs/h3-session-adapters.md).
 
 - `useJWESession(event, config)` encrypts the session payload with the provided `secret` (password string or private/symmetric JWK). Use this when session data must remain confidential. (cookie's `httpOnly: true` by default)

--- a/src/adapters/h3v1/session/types.ts
+++ b/src/adapters/h3v1/session/types.ts
@@ -27,8 +27,10 @@ export interface SessionManager<
       : number | undefined;
   readonly data: SessionData<T>;
   readonly token: string | undefined;
-  update: (
-    update: SessionUpdate<T>,
-  ) => Promise<SessionManager<T, ConfigMaxAge>>;
+  update: (update: SessionUpdate<T>) => Promise<
+    SessionManager<T, ConfigMaxAge> & {
+      readonly id: string;
+    }
+  >;
   clear: () => Promise<SessionManager<T, ConfigMaxAge>>;
 }

--- a/src/adapters/h3v2/README.md
+++ b/src/adapters/h3v2/README.md
@@ -2,6 +2,9 @@
 
 The `h3` adapter bundles session helpers that store data inside signed or encrypted JWTs.
 
+> [!WARNING]
+> While these adapters try to be compatible with h3's `useSession` API, the key difference is that new sessions are not automatically created when calling `useJWESession` or `useJWSSession`, marking their `id` as `undefined` until you explicitly call `session.update()`. This is to comply with various specs that do integrate JWT one (such as OAuth) where sessions are only created upon valid operations (like user authorization).
+
 For an in-depth guide on using these adapters, please refer to the [H3 Session Adapters - Usage Guide](../../../docs/h3-session-adapters.md).
 
 - `useJWESession(event, config)` encrypts the session payload with the provided `secret` (password string or private/symmetric JWK). Use this when session data must remain confidential. (cookie's `httpOnly: true` by default)

--- a/src/adapters/h3v2/session/jws.ts
+++ b/src/adapters/h3v2/session/jws.ts
@@ -41,7 +41,7 @@ export interface SessionJWS<
   MaxAge extends ExpiresIn | undefined = ExpiresIn | undefined,
 > {
   // Mapped from payload.jti
-  id: string;
+  id: string | undefined;
   // Mapped from payload.iat (in ms)
   createdAt: number;
   // Mapped from payload.exp (in ms)
@@ -211,12 +211,20 @@ export async function getJWSSession<
     return session;
   }
 
+  // Placeholder session object
+  const now = config.jws?.signOptions?.currentDate?.getTime() ?? Date.now();
+  const createdAt = now - (now % 1000); // round to seconds
   const session: SessionJWS<T, MaxAge> = {
-    id: "",
-    createdAt: 0,
-    expiresAt: undefined as MaxAge extends ExpiresIn ? number : T["exp"],
+    id: undefined,
+    createdAt,
+    expiresAt: (config.maxAge === undefined
+      ? undefined
+      : createdAt +
+        computeExpiresInSeconds(config.maxAge) *
+          1000) as MaxAge extends ExpiresIn ? number : T["exp"],
     data: new NullProtoObj(),
   };
+  // @ts-expect-error upstream types expect an empty id string
   context.sessions![sessionName] = session;
 
   const token = getJWSSessionToken<T, MaxAge>(event, config);
@@ -252,10 +260,6 @@ export async function getJWSSession<
       });
     session[kGetSessionPromise] = promise;
     await promise;
-  }
-
-  if (!session.id) {
-    await updateJWSSession<T, MaxAge>(event, config);
   }
 
   await config.hooks?.onRead?.({

--- a/test/h3v2-session.test.ts
+++ b/test/h3v2-session.test.ts
@@ -28,6 +28,14 @@ describe("adapter h3 v2", () => {
     beforeEach(() => {
       app = new H3({ debug: true });
 
+      app.all("/init", async (event) => {
+        const session = await useJWESession(event, sessionConfig).then((s) =>
+          s.update({}),
+        );
+
+        return { session };
+      });
+
       app.all("/", async (event) => {
         const session = await useJWESession(event, sessionConfig);
         if (event.req.method === "POST") {
@@ -74,7 +82,7 @@ describe("adapter h3 v2", () => {
     });
 
     it("initiates session", async () => {
-      const result = await app.request("/");
+      const result = await app.request("/init");
       expect(result.headers.getSetCookie()).toHaveLength(1);
       cookie = result.headers.getSetCookie()[0]!;
       expect(await result.json()).toMatchObject({
@@ -229,6 +237,14 @@ describe("adapter h3 v2", () => {
     beforeEach(() => {
       app = new H3({ debug: true });
 
+      app.all("/init", async (event) => {
+        const session = await useJWSSession(event, sessionConfig).then((s) =>
+          s.update({}),
+        );
+
+        return { session };
+      });
+
       app.all("/", async (event) => {
         const session = await useJWSSession(event, sessionConfig);
         if (event.req.method === "POST") {
@@ -275,7 +291,7 @@ describe("adapter h3 v2", () => {
     });
 
     it("initiates session", async () => {
-      const result = await app.request("/");
+      const result = await app.request("/init");
       expect(result.headers.getSetCookie()).toHaveLength(1);
       cookie = result.headers.getSetCookie()[0]!;
       expect(await result.json()).toMatchObject({


### PR DESCRIPTION
following various specs that do integrate JWT one (like OAuth) expect that we do not issue a session token by default. This makes the adapters nolonger 1:1 with the upstream implementation. But this also makes running session checks lighter, reducing server usage and overhead.